### PR TITLE
feat: add check in `checker` to verify no pendant tx is queued on the delay module

### DIFF
--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -277,9 +277,6 @@ contract RoboSaverVirtualModule {
     /// @notice Check if there is a transaction queued up in the delay module
     /// @return isTxQueued_ True if there is a transaction queued up; false otherwise
     function _isTxQueued() internal view returns (bool isTxQueued_) {
-        uint256 queueNonce = delayModule.queueNonce();
-        uint256 txNonce = delayModule.txNonce();
-
-        if (txNonce != queueNonce) isTxQueued_ = true;
+        if (delayModule.txNonce() != delayModule.queueNonce()) isTxQueued_ = true;
     }
 }

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -157,6 +157,8 @@ contract RoboSaverVirtualModule {
     /// @return adjustPoolNeeded True if there is a deficit or surplus; false otherwise
     /// @return execPayload The payload of the needed transaction
     function checker() external view returns (bool adjustPoolNeeded, bytes memory execPayload) {
+        if (_isTxQueued()) return (false, bytes("Transaction in queue, wait for it to be executed"));
+
         uint256 balance = EURE.balanceOf(CARD);
         (, uint128 dailyAllowance,,,) = rolesModule.allowances(SET_ALLOWANCE_KEY);
 
@@ -270,5 +272,14 @@ contract RoboSaverVirtualModule {
         emit PoolDepositQueued(_card, _surplus, block.timestamp);
 
         return calls_;
+    }
+
+    /// @notice Check if there is a transaction queued up in the delay module
+    /// @return isTxQueued_ True if there is a transaction queued up; false otherwise
+    function _isTxQueued() internal view returns (bool isTxQueued_) {
+        uint256 queueNonce = delayModule.queueNonce();
+        uint256 txNonce = delayModule.txNonce();
+
+        if (txNonce != queueNonce) isTxQueued_ = true;
     }
 }

--- a/test/CheckerTest.t.sol
+++ b/test/CheckerTest.t.sol
@@ -1,17 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import "forge-std/Test.sol";
-
 import {BaseFixture} from "./BaseFixture.sol";
-
-import "@balancer-v2/interfaces/contracts/vault/IVault.sol";
 
 import {Enum} from "../lib/delay-module/node_modules/@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
-import {RoboSaverVirtualModule} from "../src/RoboSaverVirtualModule.sol";
-
-contract TopupTest is BaseFixture {
+contract CheckerTest is BaseFixture {
     function testChecker_When_TopupIsRequired() public {
         (bool canExec, bytes memory execPayload) = roboModule.checker();
 

--- a/test/CheckerTest.t.sol
+++ b/test/CheckerTest.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+
+import {BaseFixture} from "./BaseFixture.sol";
+
+import "@balancer-v2/interfaces/contracts/vault/IVault.sol";
+
+import {Enum} from "../lib/delay-module/node_modules/@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+
+import {RoboSaverVirtualModule} from "../src/RoboSaverVirtualModule.sol";
+
+contract TopupTest is BaseFixture {
+    function testChecker_When_TopupIsRequired() public {
+        (bool canExec, bytes memory execPayload) = roboModule.checker();
+
+        assertFalse(canExec);
+        assertEq(execPayload, bytes("Neither deficit nor surplus; no action needed"));
+
+        uint256 tokenAmountTargetToMove = _transferOutBelowThreshold();
+
+        vm.warp(block.timestamp + COOL_DOWN_PERIOD);
+
+        bytes memory payload = abi.encodeWithSignature("transfer(address,uint256)", WETH, tokenAmountTargetToMove);
+
+        delayModule.executeNextTx(EURE, 0, payload, Enum.Operation.Call);
+
+        (canExec, execPayload) = roboModule.checker();
+
+        assertTrue(canExec, "CanExec: not executable");
+        assertEq(bytes4(execPayload), ADJUST_POOL_SELECTOR, "Selector: not adjust pool (0xba2f0056)");
+    }
+
+    function testChecker_When_TxIsOnQueue() public {
+        (bool canExec, bytes memory execPayload) = roboModule.checker();
+
+        assertFalse(canExec);
+        assertEq(execPayload, bytes("Neither deficit nor surplus; no action needed"));
+
+        // queue a tx, leverage the `_transferOutBelowThreshold` function from base fixture
+        _transferOutBelowThreshold();
+
+        (canExec, execPayload) = roboModule.checker();
+
+        assertFalse(canExec);
+        assertEq(execPayload, bytes("Transaction in queue, wait for it to be executed"));
+    }
+}

--- a/test/TopupEUReTest.t.sol
+++ b/test/TopupEUReTest.t.sol
@@ -12,26 +12,6 @@ import {Enum} from "../lib/delay-module/node_modules/@gnosis.pm/safe-contracts/c
 import {RoboSaverVirtualModule} from "../src/RoboSaverVirtualModule.sol";
 
 contract TopupTest is BaseFixture {
-    function testTopupChecker() public {
-        (bool canExec, bytes memory execPayload) = roboModule.checker();
-
-        assertFalse(canExec);
-        assertEq(execPayload, bytes("Neither deficit nor surplus; no action needed"));
-
-        uint256 tokenAmountTargetToMove = _transferOutBelowThreshold();
-
-        vm.warp(block.timestamp + COOL_DOWN_PERIOD);
-
-        bytes memory payload = abi.encodeWithSignature("transfer(address,uint256)", WETH, tokenAmountTargetToMove);
-
-        delayModule.executeNextTx(EURE, 0, payload, Enum.Operation.Call);
-
-        (canExec, execPayload) = roboModule.checker();
-
-        assertTrue(canExec, "CanExec: not executable");
-        assertEq(bytes4(execPayload), ADJUST_POOL_SELECTOR, "Selector: not adjust pool (0xba2f0056)");
-    }
-
     // @note ref for error codes: https://docs.balancer.fi/reference/contracts/error-codes.html#error-codes
     function testExitPool() public {
         uint256 initialBptBal = IERC20(BPT_STEUR_EURE).balanceOf(GNOSIS_SAFE);


### PR DESCRIPTION
closes #18 

decided to separate concrete tesst around `checker`method into its own file `CheckerTest.t.sol` since there will be more cases after our discussion around checks if enough bpt is there to fill up the deficit etc