### PR TITLE
feat: minor sanity checks during `checker`

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -1,4 +1,4 @@
-name: test
+name: Foundry
 
 on: [workflow_dispatch, pull_request]
 
@@ -7,22 +7,24 @@ env:
   GNOSIS_RPC_URL: ${{ secrets.GNOSIS_RPC_URL }}
 
 jobs:
-
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
-      - name: Run Forge build
-        run: |
-          forge --version
-          forge fmt --check
+      - name: Run Forge format
+        run: forge fmt
         id: formatting
+      - name: Auto commit
+        uses: stefanzweifel/git-auto-commit-action@v5.0.1
+        with:
+          commit_message: "style: ci lint `forge fmt`"
 
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
     strategy:
       fail-fast: true
 
-    name: Foundry project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ env:
   GNOSIS_RPC_URL: ${{ secrets.GNOSIS_RPC_URL }}
 
 jobs:
+
   format:
     runs-on: ubuntu-latest
     steps:
@@ -26,28 +27,23 @@ jobs:
   test:
     strategy:
       fail-fast: true
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
-
       - name: Install subdependencies
         run: yarn install --cwd lib/delay-module
-
       - name: Run Forge build
         run: |
           forge --version
           forge build
         id: build
-
       - name: Run Forge tests
         run: |
           forge test -vvv
-        id: test
+        id: test-trace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,23 @@ env:
   GNOSIS_RPC_URL: ${{ secrets.GNOSIS_RPC_URL }}
 
 jobs:
-  check:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Run Forge build
+        run: |
+          forge --version
+          forge fmt --check
+        id: formatting
+
+  test:
     strategy:
       fail-fast: true
 

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -240,7 +240,7 @@ contract RoboSaverVirtualModule {
 
         uint256 balance = EURE.balanceOf(CARD);
 
-        (, uint128 dailyAllowance,,,) = rolesModule.allowances(SET_ALLOWANCE_KEY);
+        (, uint128 dailyAllowance,,,) =   rolesModule.allowances(SET_ALLOWANCE_KEY);
 
         if (balance < dailyAllowance) {
             /// @notice there is a deficit; we need to withdraw from the pool

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -141,6 +141,7 @@ contract RoboSaverVirtualModule {
     error ZeroUintValue();
 
     error TooHighBps();
+    error TooLowBalance();
 
     error ExternalTxIsQueued();
 
@@ -267,7 +268,12 @@ contract RoboSaverVirtualModule {
                 _poolWithdrawal(_amount);
             }
         } else if (_action == PoolAction.DEPOSIT) {
-            _poolDeposit(_amount);
+            uint256 depositableEure = EURE.balanceOf(CARD);
+            if (depositableEure < _amount) {
+                _poolDeposit(depositableEure);
+            } else {
+                _poolDeposit(_amount);
+            }
         } else if (_action == PoolAction.EXEC_QUEUE_POOL_ACTION) {
             _executeNextTx();
         }

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -240,7 +240,7 @@ contract RoboSaverVirtualModule {
 
         uint256 balance = EURE.balanceOf(CARD);
 
-        (, uint128 dailyAllowance,,,) =   rolesModule.allowances(SET_ALLOWANCE_KEY);
+        (, uint128 dailyAllowance,,,) = rolesModule.allowances(SET_ALLOWANCE_KEY);
 
         if (balance < dailyAllowance) {
             /// @notice there is a deficit; we need to withdraw from the pool

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -141,7 +141,6 @@ contract RoboSaverVirtualModule {
     error ZeroUintValue();
 
     error TooHighBps();
-    error TooLowBalance();
 
     error ExternalTxIsQueued();
 

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -239,18 +239,14 @@ contract RoboSaverVirtualModule {
         }
 
         uint256 balance = EURE.balanceOf(CARD);
-        if (balance == 0) {
-            return (false, bytes("No EURE balance on the card"));
-        }
 
         (, uint128 dailyAllowance,,,) = rolesModule.allowances(SET_ALLOWANCE_KEY);
 
         if (balance < dailyAllowance) {
             /// @notice there is a deficit; we need to withdraw from the pool
             uint256 bptBalance = BPT_STEUR_EURE.balanceOf(CARD);
-            if (bptBalance == 0) {
-                return (false, bytes("No BPT balance on the card"));
-            }
+            if (bptBalance == 0) return (false, bytes("No BPT balance on the card"));
+
             uint256 deficit = dailyAllowance - balance;
             uint256 withdrawableEure = bptBalance * BPT_STEUR_EURE.getRate() * (MAX_BPS - slippage) / 1e18 / MAX_BPS;
             if (withdrawableEure < deficit) {

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -140,7 +140,6 @@ contract RoboSaverVirtualModule {
 
     error ZeroAddressValue();
     error ZeroUintValue();
-    error ZeroBalance();
 
     error TooHighBps();
 
@@ -239,14 +238,18 @@ contract RoboSaverVirtualModule {
         }
 
         uint256 balance = EURE.balanceOf(CARD);
-        if (balance == 0) revert ZeroBalance();
+        if (balance == 0) {
+            return (false, bytes("No EURE balance on the card"));
+        }
 
         (, uint128 dailyAllowance,,,) = rolesModule.allowances(SET_ALLOWANCE_KEY);
 
         if (balance < dailyAllowance) {
             /// @notice there is a deficit; we need to withdraw from the pool
             uint256 bptBalance = BPT_STEUR_EURE.balanceOf(CARD);
-            if (bptBalance == 0) revert ZeroBalance();
+            if (bptBalance == 0) {
+                return (false, bytes("No BPT balance on the card"));
+            }
             uint256 deficit = dailyAllowance - balance;
             uint256 withdrawableEure = bptBalance * BPT_STEUR_EURE.getRate() * (MAX_BPS - slippage) / 1e18 / MAX_BPS;
             if (withdrawableEure < deficit) {

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -22,7 +22,8 @@ contract RoboSaverVirtualModule {
     /// @notice Enum representing the different types of pool actions
     /// @custom:value0 WITHDRAW Withdraw $EURe from the pool to the card
     /// @custom:value1 DEPOSIT Deposit $EURe from the card into the pool
-    /// @custom:value2 EXEC_QUEUE_POOL_ACTION Execute the queued pool action
+    /// @custom:value2 CLOSE Close the pool position by withdrawing all to $EURe
+    /// @custom:value3 EXEC_QUEUE_POOL_ACTION Execute the queued pool action
     enum PoolAction {
         WITHDRAW,
         DEPOSIT,

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -247,7 +247,7 @@ contract RoboSaverVirtualModule {
             uint256 bptBalance = BPT_STEUR_EURE.balanceOf(CARD);
             if (bptBalance == 0) return (false, bytes("No BPT balance on the card"));
 
-            uint256 deficit = dailyAllowance - balance;
+            uint256 deficit = dailyAllowance - balance + buffer;
             uint256 withdrawableEure = bptBalance * BPT_STEUR_EURE.getRate() * (MAX_BPS - slippage) / 1e18 / MAX_BPS;
             if (withdrawableEure < deficit) {
                 return (true, abi.encodeWithSelector(this.adjustPool.selector, PoolAction.CLOSE, withdrawableEure));

--- a/test/CheckerTest.t.sol
+++ b/test/CheckerTest.t.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.25;
 
 import {BaseFixture} from "./BaseFixture.sol";
 
+import {IERC20} from "@gnosispay-kit/interfaces/IERC20.sol";
+
 import {Enum} from "../lib/delay-module/node_modules/@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 contract CheckerTest is BaseFixture {
@@ -33,5 +35,25 @@ contract CheckerTest is BaseFixture {
 
         assertFalse(canExec);
         assertEq(execPayload, bytes("External transaction in queue, wait for it to be executed"));
+    }
+
+    function testChecker_When_NoBptBalance() public {
+        _assertCheckerFalseNoDeficitNorSurplus();
+
+        // move out $EURe to get into `balance < dailyAllowance` flow and ensure BPT balance is null
+        uint256 tokenAmountTargetToMove = _transferOutBelowThreshold();
+        vm.warp(block.timestamp + COOL_DOWN_PERIOD);
+        bytes memory payload = abi.encodeWithSignature("transfer(address,uint256)", WETH, tokenAmountTargetToMove);
+        delayModule.executeNextTx(EURE, 0, payload, Enum.Operation.Call);
+
+        vm.mockCall(
+            address(BPT_STEUR_EURE), abi.encodeWithSelector(IERC20.balanceOf.selector, GNOSIS_SAFE), abi.encode(0)
+        );
+        assertEq(IERC20(BPT_STEUR_EURE).balanceOf(GNOSIS_SAFE), 0);
+
+        (bool canExec, bytes memory execPayload) = roboModule.checker();
+        vm.clearMockedCalls();
+        assertFalse(canExec);
+        assertEq(execPayload, bytes("No BPT balance on the card"));
     }
 }


### PR DESCRIPTION
i moved closing the pool to be its own `PoolAction` so that in the future we can also leverage it for a ragequit function

checks zero balances of eure and the bpt