### PR TITLE
ci: ignore coverage folders directly through forge

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -9,6 +9,3 @@ coverage:
   status:
     project: off
     patch: off
-ignore: # exclude these folders from the report
-    - "script"
-    - "test"

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -47,7 +47,7 @@ jobs:
           forge build
       - name: Run Forge tests
         run: |
-          forge coverage --report lcov -vvv
+          forge coverage --report lcov -vvv --no-match-coverage "(script|test)"
       - name: Upload coverage report to Codecov
         uses: "codecov/codecov-action@v4"
         with:


### PR DESCRIPTION
this is now possible because of https://github.com/foundry-rs/foundry/pull/8321

by keeping the scripts and tests folder out of the forge report completely we save running time and also dont need to ignore it anymore in the codecov config