### PR TITLE
perf: remove unused var from signature

### DIFF
--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -224,7 +224,7 @@ contract RoboSaverVirtualModule is
     /// @notice Check if there is a surplus or deficit of $EURe on the card
     /// @return adjustPoolNeeded True if there is a deficit or surplus; false otherwise
     /// @return execPayload The payload of the needed transaction
-    function checkUpkeep(bytes calldata)
+    function checkUpkeep(bytes calldata /* checkData */ )
         external
         view
         override

--- a/src/RoboSaverVirtualModule.sol
+++ b/src/RoboSaverVirtualModule.sol
@@ -224,7 +224,7 @@ contract RoboSaverVirtualModule is
     /// @notice Check if there is a surplus or deficit of $EURe on the card
     /// @return adjustPoolNeeded True if there is a deficit or surplus; false otherwise
     /// @return execPayload The payload of the needed transaction
-    function checkUpkeep(bytes calldata checkData)
+    function checkUpkeep(bytes calldata)
         external
         view
         override


### PR DESCRIPTION
gets rid of the following warning while still adhering to chainlink's interface:
```
Warning (5667): Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> src/RoboSaverVirtualModule.sol:227:26:
    |
227 |     function checkUpkeep(bytes calldata checkData)
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^
```