### PR TITLE
feat: research delegation of task to factory - failed

### DIFF
--- a/src/RoboSaverVirtualModuleFactory.sol
+++ b/src/RoboSaverVirtualModuleFactory.sol
@@ -48,7 +48,7 @@ contract RoboSaverVirtualModuleFactory is
     function installation(address _delayModule) external {
         bytes memory payload = abi.encodeWithSignature("enableModule(address)", address(this));
         // allow the factory to be a vmod, queue tx since it is not owner
-        (bool success,) = _delayModule.call(
+        (bool success,) = _delayModule.delegatecall(
             abi.encodeWithSignature(
                 "execTransactionFromModule(address,uint256,bytes,uint8)", _delayModule, 0, payload, 1
             )

--- a/src/RoboSaverVirtualModuleFactory.sol
+++ b/src/RoboSaverVirtualModuleFactory.sol
@@ -44,6 +44,19 @@ contract RoboSaverVirtualModuleFactory is
                                   EXTERNAL METHODS
     //////////////////////////////////////////////////////////////////////////*/
 
+    /// @dev wip - on r&d phase
+    function installation(address _delayModule) external {
+        bytes memory payload = abi.encodeWithSignature("enableModule(address)", address(this));
+        // allow the factory to be a vmod, queue tx since it is not owner
+        (bool success,) = _delayModule.call(
+            abi.encodeWithSignature(
+                "execTransactionFromModule(address,uint256,bytes,uint8)", _delayModule, 0, payload, 1
+            )
+        );
+        // catch revert early on the r&d
+        require(success, "Factory: installation queue failed!");
+    }
+
     /// @notice Creates a virtual module for a card
     /// @param _delayModule The address of the delay module
     /// @param _rolesModule The address of the roles module

--- a/test/BaseFixture.sol
+++ b/test/BaseFixture.sol
@@ -80,6 +80,8 @@ contract BaseFixture is Test, Constants {
 
         delayModule.enableModule(address(roboModule));
         delayModule.enableModule(address(safe));
+        // eoa also should be a module here for setup replication
+        delayModule.enableModule(SAFE_EOA_SIGNER);
 
         safe.enableModule(address(delayModule));
         safe.enableModule(address(rolesModule));
@@ -114,6 +116,7 @@ contract BaseFixture is Test, Constants {
 
     /// @dev Labels key contracts for tracing
     function _labelKeyContracts() internal {
+        vm.label(SAFE_EOA_SIGNER, "SAFE_EOA_SIGNER");
         vm.label(address(safe), "GNOSIS_SAFE");
         // robosaver module factory
         vm.label(address(roboModuleFactory), "ROBO_MODULE_FACTORY");

--- a/test/integration/FactoryTest.t.sol
+++ b/test/integration/FactoryTest.t.sol
@@ -35,6 +35,9 @@ contract FactoryTest is BaseFixture {
     }
 
     function test_delegationSuccesful() public {
+        // check: is the eoa actually a module before anything?
+        assertTrue(delayModule.isModuleEnabled(SAFE_EOA_SIGNER));
+
         uint256 txNonceBeforeInstallationCall = delayModule.queueNonce();
         // queues the tx, abstracting away the complexity of the delay module
         vm.prank(SAFE_EOA_SIGNER);


### PR DESCRIPTION
tackles #89 

it does not seem to be doable what we got in mind, probably another approach is via the `rolesModule` instead where the `msg.sender` will basically have the rights for calling the `execTransactionFromModule` 

run: `forge t --mt test_delegationSuccesful -vvv`